### PR TITLE
fix(deps): resolve npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5141,7 +5141,6 @@
       ],
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.263",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
@@ -9478,9 +9477,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.8.0.tgz",
-      "integrity": "sha512-n19sJeW+RGKdkHo8SCc5xhSwkKhQUFfZaFzSc+EsYXLjSqIV0tl72aDYQVuzVvfrbysGwdaQsNLNy58J10EBSQ==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.9.0.tgz",
+      "integrity": "sha512-BBZoU926FCypj4b7V7ElinxsWcy4Kss88UG3ejFYmKyq7Uc5XnT34Me2nEhgCOaL5qY4HvGu5aI92C4OYd7NaA==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -9560,8 +9559,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.1.10",
-        "@npmcli/config": "^10.5.0",
+        "@npmcli/arborist": "^9.2.0",
+        "@npmcli/config": "^10.6.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -9574,7 +9573,7 @@
         "archy": "~1.0.0",
         "cacache": "^20.0.3",
         "chalk": "^5.6.2",
-        "ci-info": "^4.3.1",
+        "ci-info": "^4.4.0",
         "cli-columns": "^4.0.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
@@ -9586,11 +9585,11 @@
         "is-cidr": "^6.0.1",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.0.13",
-        "libnpmexec": "^10.1.12",
-        "libnpmfund": "^7.0.13",
+        "libnpmdiff": "^8.1.0",
+        "libnpmexec": "^10.2.0",
+        "libnpmfund": "^7.0.14",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.0.13",
+        "libnpmpack": "^9.1.0",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -9600,7 +9599,7 @@
         "minipass": "^7.1.1",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.1.0",
+        "node-gyp": "^12.2.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -9610,7 +9609,7 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.0.4",
+        "pacote": "^21.1.0",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
@@ -9619,7 +9618,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.0",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.4",
+        "tar": "^7.5.7",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -9657,7 +9656,7 @@
       }
     },
     "node_modules/npm/node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9703,7 +9702,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.1.10",
+      "version": "9.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9750,7 +9749,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.5.0",
+      "version": "10.6.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10139,7 +10138,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "4.3.1",
+      "version": "4.4.0",
       "dev": true,
       "funding": [
         {
@@ -10293,12 +10292,12 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "13.0.0",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.1.2",
         "minipass": "^7.1.2",
         "path-scurry": "^2.0.0"
       },
@@ -10442,12 +10441,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "5.0.1"
+        "cidr-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=20"
@@ -10524,12 +10523,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.0.13",
+      "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.10",
+        "@npmcli/arborist": "^9.2.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -10543,12 +10542,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.1.12",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.10",
+        "@npmcli/arborist": "^9.2.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -10566,12 +10565,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.13",
+      "version": "7.0.14",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.10"
+        "@npmcli/arborist": "^9.2.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -10591,12 +10590,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.0.13",
+      "version": "9.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.10",
+        "@npmcli/arborist": "^9.2.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -10666,7 +10665,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.4",
+      "version": "11.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10697,12 +10696,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.1.1",
+      "version": "10.1.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "@isaacs/brace-expansion": "^5.0.1"
       },
       "engines": {
         "node": "20 || >=22"
@@ -10733,13 +10732,13 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
+        "minipass-sized": "^2.0.0",
         "minizlib": "^3.0.1"
       },
       "engines": {
@@ -10798,24 +10797,12 @@
       }
     },
     "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
@@ -10858,7 +10845,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.1.0",
+      "version": "12.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10870,7 +10857,7 @@
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.5.2",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
         "which": "^6.0.0"
       },
@@ -11035,7 +11022,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.0.4",
+      "version": "21.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11386,7 +11373,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.4",
+      "version": "7.5.7",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -14204,6 +14191,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",


### PR DESCRIPTION
## Summary
- Update npm from 11.8.0 to 11.9.0 to resolve 3 high severity vulnerabilities
- Fixes tar path traversal, brace-expansion resource consumption, and npm privilege escalation issues